### PR TITLE
Bump ansible-core version maximum to 2.14

### DIFF
--- a/ansible_mitogen/loaders.py
+++ b/ansible_mitogen/loaders.py
@@ -49,7 +49,7 @@ __all__ = [
 
 
 ANSIBLE_VERSION_MIN = (2, 10)
-ANSIBLE_VERSION_MAX = (2, 13)
+ANSIBLE_VERSION_MAX = (2, 14)
 
 NEW_VERSION_MSG = (
     "Your Ansible version (%s) is too recent. The most recent version\n"


### PR DESCRIPTION
Ansible 2.14 release notes can be found here: https://github.com/ansible/ansible/blob/stable-2.14/changelogs/CHANGELOG-v2.14.rst 

Nothing obvious I can see that would break things. 2.14 seems to be working fine for all my playbooks using current mitogen.